### PR TITLE
issue-18 FAQ pages as posts with tags

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -32,7 +32,7 @@
                 </li> -->
 
                 <li>
-                    <a href="{{ site.baseurl }}/faq/faq">Faq</a>
+                    <a href="{{ site.baseurl }}/faq/">Faq</a>
                 </li>
 
 

--- a/_posts/2020-08-18-restart-agent.md
+++ b/_posts/2020-08-18-restart-agent.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "How do I (re)start the agent?"
+description: ""
+tags:
+ - agent
+excerpt_separator: <!--more-->
+---
+# How do I (re)start the agent?
+
+To start the native binary agent (usually on Linux), you would need to run it as root:
+
+``` shell
+sudo systemctl start horizon
+```
+
+<!--more-->
+
+The method used to start or restart the agent differs slightly depending on two factors:
+* your operating system
+* if the agent is a native binary or running in a container
+
+If you are running the agent on OSX, it is containerized.  To start the containerized agent, use the following command:
+
+``` shell
+horizon-container start
+```
+

--- a/faq/index.md
+++ b/faq/index.md
@@ -1,0 +1,16 @@
+---
+layout: page
+title: "FAQ"
+description: "Got questions? We've got answers."
+---
+
+{% for tag in site.tags %}
+  <h3>{{ tag[0] }}</h3>
+  <ul>
+    {% for post in tag[1] %}
+        <li>
+            {{ post.excerpt }}
+        </li>
+    {% endfor %}
+  </ul>
+{% endfor %}


### PR DESCRIPTION
Signed-off-by: Joe Pearson <joe.pearsonus.ibm.com@joes-mbp.usga.ibm.com>

I renamed the faq page as index.md so it would be available at /faq/ and created a post in `_posts` of type post with a tag of agent, then modified the FAQ index page to iterate over the tags to display.

The posts layout template is wrong and there are some formatting issues, but it appears that this approach works.