### PR TITLE
FIX: Escape the greater than sign in the installation prereqs

### DIFF
--- a/common-requests/install.md
+++ b/common-requests/install.md
@@ -10,7 +10,7 @@ description: "Instructions for installing the Open Horizon project's Management 
 
 To run the [all-in-one instructions](https://github.com/open-horizon/devops/tree/master/mgmt-hub) for the Management Hub, Agent, and CLI all in one VM, you need a VM with: 
 
-* >= 4GB RAM 
+* &gt;= 4GB RAM
 * 20GB storage 
 * Ubuntu Server 18.04 LTS
 


### PR DESCRIPTION
The ">" symbol was interpreted in markdown as a blockquote element, as seen below.
![image](https://user-images.githubusercontent.com/24197092/94507653-16f0d880-01c5-11eb-8e25-ce889b99702d.png)

The intent is for the text to state ">= 4GB RAM", as seen below.
![image](https://user-images.githubusercontent.com/24197092/94507870-86ff5e80-01c5-11eb-8f45-0c6d441c0f21.png)


Signed-off-by: Clement Ng <clementdng@gmail.com>