### PR TITLE
Expands rendered json blocks

### DIFF
--- a/common-requests/use.md
+++ b/common-requests/use.md
@@ -37,7 +37,7 @@ Use `node` to find the node configuration from the agent:
 
 The response should be similar to this JSON example:
 
-``` json
+``` javascript
 {
   "id": "node1",
   "organization": "myorg",
@@ -80,7 +80,7 @@ Check the agreement formed when your edge node registered for a service:
 
 This command displays a JSON array of objects showing one or more active agreements between the edge node and AgBots:
 
-``` json
+``` javascript
 [
   {
     "name": "Policy for myorg/node1 merged with myorg/policy-ibm.helloworld_1.0.0",


### PR DESCRIPTION
Signed-off-by: codejaeger <mandaldebabrata123@gmail.com>

This is a possible fix to issue #50 which preserves syntax highlighting as well as expands the ` ```json ` response blocks. 