### PR TITLE
Fixed overlapping text in header

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@ description: Welcome to the Open Horizon (OH) documentation site, where you can 
 <title>{{site.data.keyword.edge_notm}} documentation site</title>
 <link rel="stylesheet" type="text/css" href="https://www.ibm.com/support/knowledgecenter/css/welcome.css" />
 <link type="text/css" href="https://1.www.s81c.com/common/v18/r140/css/www.css" rel="stylesheet" />
-<link type="text/css" href="https://1.www.s81c.com/common/v18/r140/css/www.css" rel="stylesheet" />
+<style> h1 {line-height: 1.1; font-weight: 800} </style>
 <link type="text/css" href="https://1.www.s81c.com/common/v18/r140/css/tables.css" rel="stylesheet" />
 <script type="text/javascript" charset="utf-8" src="https://1.www.s81c.com/common/v18/r140/js/www.js"></script>
 <script type="text/javascript" charset="utf-8" src="https://1.www.s81c.com/common/v18/r140/js/tables.js"></script>


### PR DESCRIPTION
Signed-off-by: Anthony Mangiacapra <tonymang72@gmail.com>

This is a draft solution for issue #73 

An imported file, `www.css`, overwrites the `line-height` and `font-weight` values being used by other pages of the same type, which results in the differences on this specific page. This file is necessary for the formatting of other parts of the page, however manually overwriting `line-height` and `font-weight` to the correct values fixes the problem on the surface. It was also included twice on consecutive lines, so I've deleted the duplicate.

This contains one solution, specific to this file, however another solution would be to assign `line-height` and `font-weight` in `_layouts/page.html` for the specific line being affected here. This would have the same affect and doesn't change the other files using this layout from what I can tell. I'm including the fix that is unique to this specific file, but if this other option seems more preferable I can move to that. Any other input on a better way to fix this is welcome.

Here's a picture of what the page looks like now. I've tested it in both Firefox and Safari.

![docs_header_fixed](https://user-images.githubusercontent.com/22260911/122086891-27d48f00-cdd2-11eb-8a2a-c1b5ac4af64f.png)

