### PR TITLE
Issue-204: Agbot keyword variable fixes

### DIFF
--- a/_data/keyword.yml
+++ b/_data/keyword.yml
@@ -1,3 +1,5 @@
+agbot:
+  Agbot
 cloud:
   IBM&reg; Cloud
 cloud_notm:
@@ -49,11 +51,11 @@ horizon_open:
 horizon:
   Horizon
 horizon_agbot:
-  Horizon agbot
+  Horizon Agbot
 horizon_agbots:
-  Horizon agbots
+  Horizon Agbots
 horizon_agbot_full:
-  Horizon agreement bot (agbot)
+  Horizon agreement bot (Agbot)
 horizon_agent:
   Horizon agent
 horizon_agents:

--- a/docs/api/agbot_api.md
+++ b/docs/api/agbot_api.md
@@ -1,9 +1,9 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
-title: Agbot API
+years: 2021 - 2022
+lastupdated: "2022-03-10"
+title: {{site.data.keyword.agbot}} API
 description: An Agreement Bot API is a REST API which uses agreements with edge nodes to run edge services to fulfill the patterns and deployment policies specified.
 ---
 
@@ -15,11 +15,11 @@ description: An Agreement Bot API is a REST API which uses agreements with edge 
 {:child: .link .ulchildlink}
 {:childlinks: .ullinks}
 
-# Agbot API
+# {{site.data.keyword.agbot}} API
 {: #agbot_api}
 
-In {{site.data.keyword.edge_notm}} ({{site.data.keyword.ieam}}), the {{site.data.keyword.horizon}} agbot software runs automatically. Each agbot is responsible for communicating with all of the agents that are registered to run services by negotiating agreements with the agents. The `hzn agbot` commands interact with these REST APIs. These APIs are not remotely accessible; they can only be used by processes running on the same host as the agbot.
+In {{site.data.keyword.edge_notm}} ({{site.data.keyword.ieam}}), the {{site.data.keyword.horizon}} {{site.data.keyword.agbot}} software runs automatically. Each {{site.data.keyword.agbot}} is responsible for communicating with all of the agents that are registered to run services by negotiating agreements with the agents. The `hzn agbot` commands interact with these REST APIs. These APIs are not remotely accessible; they can only be used by processes running on the same host as the {{site.data.keyword.agbot}}.
 
 For more information, see [{{site.data.keyword.horizon}} Agreement Bot APIs](https://github.com/open-horizon/anax/blob/master/docs/agreement_bot_api.md).
 
-{{site.data.keyword.horizon_exchange}} also exposes agbot configuration REST APIs, which are accessed by the `hzn exchange agbot` command.
+{{site.data.keyword.horizon_exchange}} also exposes {{site.data.keyword.agbot}} configuration REST APIs, which are accessed by the `hzn exchange agbot` command.

--- a/docs/developing/secrets_details.md
+++ b/docs/developing/secrets_details.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-08-16"
+years: 2021 - 2022
+lastupdated: "2022-03-10"
 
 ---
 
@@ -17,7 +17,7 @@ lastupdated: "2021-08-16"
 # Developing a service using secrets
 {: #using secrets}
 
-<img src="../images/edge/10_Secrets.svg" style="margin: 3%" alt="Developing a service using secrets"> 
+<img src="../images/edge/10_Secrets.svg" style="margin: 3%" alt="Developing a service using secrets">
 
 # Secrets Manager details
 {: #secrets_details}
@@ -39,7 +39,7 @@ A user without admin privileges can:
 - List all organization wide secrets, but cannot add, remove or read them.
 - Add, remove, read and list all secrets private to that user.
 
-The {{site.data.keyword.ieam}} Agbot also has access to secrets in order to be able to deploy them to edge nodes. The agbot maintains a renewable login to the Vault and is given ACL policies specific to its purposes. An agbot can:
+The {{site.data.keyword.ieam}} {{site.data.keyword.agbot}} also has access to secrets in order to be able to deploy them to edge nodes. The {{site.data.keyword.agbot}} maintains a renewable login to the Vault and is given ACL policies specific to its purposes. An {{site.data.keyword.agbot}} can:
 - Read org wide secrets and any user private secret in any org, but it cannot add, remove or list any secrets.
 
 The Exchange root user and Exchange hub admins have no permissions in the Vault. See [Role-Based Access Control](../user_management/rbac.html) for more info on these roles.

--- a/docs/getting_started/faq.md
+++ b/docs/getting_started/faq.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2021 - 2022
+lastupdated: "2022-03-10"
 
 ---
 
@@ -39,7 +39,7 @@ The following are answers to some frequently asked questions (FAQs) about {{site
 ## Is there a way to create a self-contained environment for development purposes?
 {: one_click}
 
-You can install the open source management hub (without the {{site.data.keyword.ieam}} management console) with the “all-in-one” installer for developers. The all-in-one installer creates a complete but minimal management hub, not suitable for production use. It also configures an example edge node. This tool enables open source component developers to get started quickly without the time it takes to configure a complete production {{site.data.keyword.ieam}} management hub. For information about the all-in-one installer, see [Open Horizon - Devops ](https://github.com/open-horizon/devops/tree/master/mgmt-hub){:target="_blank"}{: .externalLink}.
+You can install the open source management hub (without the {{site.data.keyword.ieam}} management console) with the "all-in-one" installer for developers. The all-in-one installer creates a complete but minimal management hub, not suitable for production use. It also configures an example edge node. This tool enables open source component developers to get started quickly without the time it takes to configure a complete production {{site.data.keyword.ieam}} management hub. For information about the all-in-one installer, see [Open Horizon - Devops ](https://github.com/open-horizon/devops/tree/master/mgmt-hub){:target="_blank"}{: .externalLink}.
 
 ## Is {{site.data.keyword.ieam}} software open-sourced?
 {: #open_sourced}
@@ -77,7 +77,7 @@ If your software requires access to specific hardware or operating system servic
 ## Is there detailed documentation for the REST APIs provided by the components in {{site.data.keyword.ieam}}?
 {: #rest_doc}
 
-Yes. For more information, see [{{site.data.keyword.ieam}} APIs](../api/). 
+Yes. For more information, see [{{site.data.keyword.ieam}} APIs](../api/).
 
 ## Does {{site.data.keyword.ieam}} use Kubernetes?
 {: #use_kube}
@@ -92,9 +92,9 @@ Yes. {{site.data.keyword.ieam}} uses [{{site.data.keyword.open_shift_cp}} ](http
 ## How long does it normally take after registering an edge node before agreements are formed, and the corresponding containers start running?
 {: #agree_run}
 
-Typically, it takes only a few seconds after registration for the agent and a remote agbot to finalize an agreement to deploy software. After that occurs, the {{site.data.keyword.horizon}} agent downloads (`docker pull`) your containers to the edge node, verify their cryptographic signatures with {{site.data.keyword.horizon_exchange}}, and run them. Depending on the sizes of your containers, and the time it takes them to start and be functional, it can take from just a few more seconds, to many minutes before the edge node is fully operational.
+Typically, it takes only a few seconds after registration for the agent and a remote {{site.data.keyword.agbot}} to finalize an agreement to deploy software. After that occurs, the {{site.data.keyword.horizon}} agent downloads (`docker pull`) your containers to the edge node, verify their cryptographic signatures with {{site.data.keyword.horizon_exchange}}, and run them. Depending on the sizes of your containers, and the time it takes them to start and be functional, it can take from just a few more seconds, to many minutes before the edge node is fully operational.
 
-After you have registered an edge node, you can run the `hzn node list` command to view the state of {{site.data.keyword.horizon}} on your edge node. When the `hzn node list` command shows that the state is `configured`, the {{site.data.keyword.horizon}} agbots are able to discover the edge node and begin to form agreements.
+After you have registered an edge node, you can run the `hzn node list` command to view the state of {{site.data.keyword.horizon}} on your edge node. When the `hzn node list` command shows that the state is `configured`, the {{site.data.keyword.horizon}} {{site.data.keyword.agbot}}s are able to discover the edge node and begin to form agreements.
 
 To observe the agreement negotiation process phases, you can use the `hzn agreement list` command.
 
@@ -103,14 +103,14 @@ After an agreement list is finalized, you can use the `docker ps` command to vie
 ## Can the {{site.data.keyword.horizon}} software and all other software or data that is related to {{site.data.keyword.ieam}} be removed from an edge node host?
 {: #sw_rem}
 
-Yes. If your edge node is registered, unregister the edge node by running: 
-{% capture code %}hzn unregister -f -r{% endcapture %} 
+Yes. If your edge node is registered, unregister the edge node by running:
+{% capture code %}hzn unregister -f -r{% endcapture %}
 
 {% include code_snippet.md code=code language='shell' %}
 
 When the edge node is unregistered, you can remove the installed {{site.data.keyword.horizon}} software, for example for Debian-based systems run:
 
-{% capture code %}sudo apt purge -y bluehorizon horizon horizon-cli{% endcapture %} 
+{% capture code %}sudo apt purge -y bluehorizon horizon horizon-cli{% endcapture %}
 
 {% include code_snippet.md code=code language='shell' %}
 
@@ -123,19 +123,19 @@ Also, you can use the `hzn` command to obtain information about the active agree
 
 {% capture code %}hzn node list
 hzn agreement list
-docker ps{% endcapture %} 
+docker ps{% endcapture %}
 
 {% include code_snippet.md code=code language='shell' %}
 
 ## What happens if a container image download is interrupted by a network outage?
 {: #image_download}
 
-The docker API is used to download container images. If the docker API terminates the download, it returns an error to the agent. In turn, the agent cancels the current deployment attempt. When the Agbot detects the cancellation, it initiates a new deployment attempt with the agent. During the subsequent deployment attempt, the docker API resumes the download from where it left off. This process continues until the image is fully downloaded and the deployment can proceed. The docker binding API is responsible for the image pull, and in case of failure, the agreement is canceled.
+The docker API is used to download container images. If the docker API terminates the download, it returns an error to the agent. In turn, the agent cancels the current deployment attempt. When the {{site.data.keyword.agbot}} detects the cancellation, it initiates a new deployment attempt with the agent. During the subsequent deployment attempt, the docker API resumes the download from where it left off. This process continues until the image is fully downloaded and the deployment can proceed. The docker binding API is responsible for the image pull, and in case of failure, the agreement is canceled.
 
 ## How is {{site.data.keyword.ieam}} secure?
 {: #ieam_secure}
 
-* {{site.data.keyword.ieam}} automates and uses cryptographically signed public-private key authentication of edge devices as it communicates with the {{site.data.keyword.ieam}} management hub during provisioning. Communication is always initiated and controlled by the edge node. 
+* {{site.data.keyword.ieam}} automates and uses cryptographically signed public-private key authentication of edge devices as it communicates with the {{site.data.keyword.ieam}} management hub during provisioning. Communication is always initiated and controlled by the edge node.
 * System has node and service credentials.
 * Software verification and authenticity using hash verification.
 

--- a/docs/hub/cluster_sizing.md
+++ b/docs/hub/cluster_sizing.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2021 - 2022
+lastupdated: "2022-03-10"
 
 ---
 
@@ -49,7 +49,7 @@ oc get storageclass <desired storage class> -o json | jq .allowVolumeExpansion
 ```
 {: codeblock}
 
-If the storage class allows volume expansion, sizing can be adjusted post installation (given the underlying storage space is available for allocation). If the storage class does not allow volume expansion, you must pre-allocate storage for your use case. 
+If the storage class allows volume expansion, sizing can be adjusted post installation (given the underlying storage space is available for allocation). If the storage class does not allow volume expansion, you must pre-allocate storage for your use case.
 
 If more storage is necessary after initial installation with a storage class that does not allow for volume expansion, you will need to run through a re-installation using the steps that are described in the [backup and recovery](../admin/) page.
 
@@ -57,7 +57,7 @@ The allocations can be changed before the {{site.data.keyword.ieam}} Management 
 
 * PostgreSQL Exchange (Stores data for the exchange, and fluctuates in size depending on usage, but the default storage setting can support up to 10,000 devices)
   * 20 GB
-* PostgreSQL AgBot (Stores data for the agbot, the default storage setting can support up to 10,000 devices)
+* PostgreSQL {{site.data.keyword.agbot}} (Stores data for the {{site.data.keyword.agbot}}, the default storage setting can support up to 10,000 devices)
   * 20 GB
 * MongoDB Cloud Sync Service (stores content for the Model Management Service (MMS). Depending on the number and size of your models, you might want to modify this default allocation.
   * 50 GB

--- a/docs/installing/edge_clusters.md
+++ b/docs/installing/edge_clusters.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2021 - 2022
+lastupdated: "2022-03-10"
 
 ---
 
@@ -19,7 +19,7 @@ lastupdated: "2021-02-20"
 
 {{site.data.keyword.edge_notm}} ({{site.data.keyword.ieam}}) edge cluster capability helps you manage and deploy workloads from a management hub cluster to remote instances of OpenShift® Container Platform or other Kubernetes-based clusters. Edge clusters are {{site.data.keyword.ieam}} edge nodes that are Kubernetes clusters. An edge cluster enables use cases at the edge, which require colocation of compute with business operations, or that require more scalability, availability, and compute capability than what can be supported by an edge device. Further, it is not uncommon for edge clusters to provide application services that are needed to support services running on edge devices due to their close proximity to edge devices. {{site.data.keyword.ieam}} deploys edge services to an edge cluster, via a Kubernetes operator, enabling the same autonomous deployment mechanisms used with edge devices. The full power of Kubernetes as a container management platform is available for edge services that are deployed by {{site.data.keyword.ieam}}.
 
-<img src="../images/edge/05b_Installing_edge_agent_on_cluster.svg" style="margin: 3%" alt="{{site.data.keyword.horizon_exchange}}, agbots and agents">
+<img src="../images/edge/05b_Installing_edge_agent_on_cluster.svg" style="margin: 3%" alt="{{site.data.keyword.horizon_exchange}}, {{site.data.keyword.agbot}}s and agents">
 
 The following sections describe how to install an edge cluster and install the {{site.data.keyword.ieam}} agent on it.
 

--- a/docs/installing/edge_devices.md
+++ b/docs/installing/edge_devices.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2021 - 2022
+lastupdated: "2022-03-10"
 
 ---
 
@@ -25,8 +25,8 @@ An edge device provides an entry point into enterprise or service provider core 
 * [Installing the agent](../installing/registration.md)
 * [Updating the agent](../installing/updating_the_agent.md)
 
-All edge devices (edge nodes) require the {{site.data.keyword.horizon_agent}} software to be installed. The {{site.data.keyword.horizon_agent}} also depends upon [Docker ](https://www.docker.com/){:target="_blank"}{: .externalLink} software. 
+All edge devices (edge nodes) require the {{site.data.keyword.horizon_agent}} software to be installed. The {{site.data.keyword.horizon_agent}} also depends upon [Docker ](https://www.docker.com/){:target="_blank"}{: .externalLink} software.
 
 Focusing in on the edge device, the following diagram shows the flow of the steps you perform to set up the edge device, and what the agent does after it is started.
 
-<img src="../images/edge/05a_Installing_edge_agent_on_device.svg" style="margin: 3%" alt="{{site.data.keyword.horizon_exchange}}, agbots and agents">
+<img src="../images/edge/05a_Installing_edge_agent_on_device.svg" style="margin: 3%" alt="{{site.data.keyword.horizon_exchange}}, {{site.data.keyword.agbot}}s and agents">

--- a/docs/installing/exchange_api.md
+++ b/docs/installing/exchange_api.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2021 - 2022
+lastupdated: "2022-03-10"
 
 ---
 
@@ -17,6 +17,6 @@ lastupdated: "2021-02-20"
 # Exchange API
 {: #exchange_api}
 
-{{site.data.keyword.horizon_exchange}} provides a discovery mechanism for agbots to find agents. Agents use the {{site.data.keyword.horizon_exchange}} REST APIs to register with {{site.data.keyword.horizon_exchange}}. Currently, {{site.data.keyword.horizon_exchange}} REST APIs are not available to users.
+{{site.data.keyword.horizon_exchange}} provides a discovery mechanism for {{site.data.keyword.agbot}}s to find agents. Agents use the {{site.data.keyword.horizon_exchange}} REST APIs to register with {{site.data.keyword.horizon_exchange}}. Currently, {{site.data.keyword.horizon_exchange}} REST APIs are not available to users.
 
 See [Horizon Data Exchange Server and REST API ](https://github.com/open-horizon/exchange-api){:target="_blank"}{: .externalLink}.

--- a/docs/troubleshoot/index.md
+++ b/docs/troubleshoot/index.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2021 - 2022
+lastupdated: "2022-03-10"
 
 ---
 
@@ -41,7 +41,7 @@ Review the following questions when you encounter an issue with {{site.data.keyw
 
 Ensure that the {{site.data.keyword.horizon}} software that is installed on your edge nodes is always on the latest released version.
 
-On a {{site.data.keyword.linux_notm}} system, you can usually check the version of your installed {{site.data.keyword.horizon}} packages by running this command:  
+On a {{site.data.keyword.linux_notm}} system, you can usually check the version of your installed {{site.data.keyword.horizon}} packages by running this command:
 ```
 dpkg -l | grep horizon
 ```
@@ -74,7 +74,7 @@ Active: active (running) since Thu 2020-10-01 17:56:12 UTC; 2 weeks 0 days ago
 ```
 {: codeblock}
 
-## Is the edge node configured to interact with the {{site.data.keyword.horizon_exchange}}? 
+## Is the edge node configured to interact with the {{site.data.keyword.horizon_exchange}}?
 {: #node_configured}
 
 To verify that you can communicate with the {{site.data.keyword.horizon_exchange}}, run this command:
@@ -98,7 +98,7 @@ hzn node list | jq .configuration.exchange_api
 ## Are the required Docker containers for the edge node running?
 {: #node_running}
 
-When your edge node is registered with {{site.data.keyword.horizon}}, a {{site.data.keyword.horizon}} Agbot creates an agreement with your edge node to run the services that are referenced in your gateway type (deployment pattern). If that agreement is not created, complete these checks to troubleshoot the issue.
+When your edge node is registered with {{site.data.keyword.horizon}}, a {{site.data.keyword.horizon}} {{site.data.keyword.agbot}} creates an agreement with your edge node to run the services that are referenced in your gateway type (deployment pattern). If that agreement is not created, complete these checks to troubleshoot the issue.
 
 Confirm that your edge node is in the `configured` state and has the correct `id`, `organization` values. Additionally, confirm that the architecture that {{site.data.keyword.horizon}} is reporting is the same architecture that you used in the metadata for your services. Run this command to list these settings:
 ```
@@ -106,31 +106,31 @@ hzn node list | jq .
 ```
 {: codeblock}
 
-If those values are as expected, you can check the agreement status of the edge node by run: 
+If those values are as expected, you can check the agreement status of the edge node by run:
 ```
 hzn agreement list | jq .
 ```
 {: codeblock}
 
-If this command does not show any agreements; those agreements might have formed, but a problem might have been discovered. If this occurs, the agreement can be cancelled before it can display in the output from the previous command. If an agreement cancellation occurs, the cancelled agreement shows a status of `terminated_description` in the list of archived agreements. You can view the archived list by running this command: 
+If this command does not show any agreements; those agreements might have formed, but a problem might have been discovered. If this occurs, the agreement can be cancelled before it can display in the output from the previous command. If an agreement cancellation occurs, the cancelled agreement shows a status of `terminated_description` in the list of archived agreements. You can view the archived list by running this command:
 ```
 hzn agreement list -r | jq .
 ```
 {: codeblock}
 
-A problem might also occur before an agreement is created. If this problem occurs, review the event log for the {{site.data.keyword.horizon}} agent to identify possible errors. Run this command to view the log: 
+A problem might also occur before an agreement is created. If this problem occurs, review the event log for the {{site.data.keyword.horizon}} agent to identify possible errors. Run this command to view the log:
 ```
 hzn eventlog list
-``` 
+```
 {: codeblock}
 
-The event log can include: 
+The event log can include:
 
 * The signature of the service metadata, specifically the `deployment` field, cannot be verified. This error usually means that your signing public key is not imported into your edge node. You can import the key by using the `hzn key import -k <pubkey>` command. You can view the keys that are imported to your local edge node by using the `hzn key list` command. You can verify that the service metadata in the {{site.data.keyword.horizon_exchange}} is signed with your key by using this command:
   ```
   hzn exchange service verify -k $PUBLIC_KEY_FILE <service-id>
   ```
-  {: codeblock} 
+  {: codeblock}
 
 Replace `<service-id>` with the ID for your service. This ID can resemble the following sample format: `workload-cpu2wiotp_${CPU2WIOTP_VERSION}_${ARCH2}`.
 
@@ -206,7 +206,7 @@ docker network list
 
 To view more information about networks, use the `docker inspect X` command, where `X` is the name of the network. The command output lists all containers that run on the virtual network.
 
-You can also run the `docker inspect Y` command on each container, where `Y` is the name of the container, to get more information. For instance, review the `NetworkSettings` container information and search the `Networks` container. Within this container, you can view the relevant network ID string and information about how the container is represented on the network. This representation information includes the container `IPAddress`, and the list of network aliases that are on this network. 
+You can also run the `docker inspect Y` command on each container, where `Y` is the name of the container, to get more information. For instance, review the `NetworkSettings` container information and search the `Networks` container. Within this container, you can view the relevant network ID string and information about how the container is represented on the network. This representation information includes the container `IPAddress`, and the list of network aliases that are on this network.
 
 Alias names are available to all of the containers on this virtual network, and these names are typically used by the containers in your code deployment pattern for discovering other containers on the virtual network. For example, you can name your service `myservice`. Then, other containers can use that name directly to access it on the network, such as with the command `ping myservice`. The alias name of your container is specified in the `deployment` field of its service definition file that you passed to the `hzn exchange service publish` command.
 
@@ -263,7 +263,7 @@ If the subscription command is successful, the command blocks indefinitely. The 
 
 For example, to review the log for the `cpu2evtstreams` service, run this command:
 
-* For {{site.data.keyword.linux_notm}} and {{site.data.keyword.windows_notm}} 
+* For {{site.data.keyword.linux_notm}} and {{site.data.keyword.windows_notm}}
 
 ```bash
 tail -n 500 -f /var/log/syslog | grep -E 'cpu2evtstreams\[[0-9]+\]:'
@@ -295,7 +295,7 @@ The parameter `$ORG_ID` is your organization ID, and `$SERVICE` is the name of t
 ## Does your published deployment pattern include all required services and versions?
 {: #services_included}
 
-On any edge node where the `hzn` command is installed, you can use this command to get details about any deployment pattern. Run the `hzn` command with the following arguments to pull the listing of deployment patterns from the {{site.data.keyword.horizon_exchange}}: 
+On any edge node where the `hzn` command is installed, you can use this command to get details about any deployment pattern. Run the `hzn` command with the following arguments to pull the listing of deployment patterns from the {{site.data.keyword.horizon_exchange}}:
 
 ```
 hzn exchange pattern list | jq .
@@ -353,12 +353,12 @@ This error occurs when the service image that is referenced in the service defin
     ```
     {: codeblock}
 
-2. Push the service image directly to the image repository. 
+2. Push the service image directly to the image repository.
     ```
     docker push <image name>
     ```
-    {: codeblock} 
-    
+    {: codeblock}
+
 ### Deployment configuration error
 {: #eidc}
 
@@ -372,13 +372,13 @@ This error occurs when the service definitions deployment configurations specify
 
 This error occurs when docker encounters an error when it starts the service container. The error message might contain details that indicate why the container start failed. Error resolution steps depend on the error. The following errors can occur:
 
-1. The device is already using a published port that is specified by the deployment configurations. To resolve the error: 
+1. The device is already using a published port that is specified by the deployment configurations. To resolve the error:
 
     - Map a different port to the service container port. The displayed port number does not have to match the service port number.
     - Stop the program that is using the same port.
 
 2. A published port that is specified by the deployment configurations is not a valid port number. Port numbers must be a number in the range 1 -  65535.
-3. A volume name in the deployment configurations is not a valid file path. Volume paths must be specified by their absolute (not relative) paths. 
+3. A volume name in the deployment configurations is not a valid file path. Volume paths must be specified by their absolute (not relative) paths.
 
 ## How to uninstall Podman on RHEL?
 {: #uninstall_podman}
@@ -411,16 +411,16 @@ cd ~ && rm -rf /.local/share/containers/
   ```
   Error from server: error dialing backend: remote error: tls: internal error
   ```
-  {: codeblock} 
+  {: codeblock}
 
-If you see this error at the end of the cluster agent-install process or while trying to interact with the agent pod, there might be an issue with the Certificate Signing Requests (CSR) of your OCP cluster. 
+If you see this error at the end of the cluster agent-install process or while trying to interact with the agent pod, there might be an issue with the Certificate Signing Requests (CSR) of your OCP cluster.
 
 1. Check if you have any CSRs in the Pending state:
 
     ```
     oc get csr
     ```
-    {: codeblock} 
+    {: codeblock}
 
 2. Approve the pending CSRs:
 
@@ -428,7 +428,7 @@ If you see this error at the end of the cluster agent-install process or while t
   oc adm certificate approve <csr-name>
   ```
   {: codeblock}
-    
+
 **Note**: You can approve all of the CSRs with one command:
 
   ```

--- a/docs/user_management/rbac.md
+++ b/docs/user_management/rbac.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2021 - 2022
+lastupdated: "2022-03-10"
 
 ---
 
@@ -39,14 +39,14 @@ There are four types of identities within {{site.data.keyword.ieam}}:
   * IAM API keys (used with the **hzn** command) behave like IAM users
 * Exchange-only users: The exchange root user is an example of this. You usually do not need to create other local exchange-only users. As a best practice, manage users in IAM, and use those user credentials (or API keys associated with those users) to authenticate to {{site.data.keyword.ieam}}.
 * Exchange nodes (edge devices or edge clusters)
-* Exchange agbots
+* Exchange {{site.data.keyword.agbot}}s
 
 ### Role-Based Access Control (RBAC)
 {: #rbac_roles}
 
 {{site.data.keyword.ieam}} includes the following roles:
 
-| **Role**    | **Access**    |  
+| **Role**    | **Access**    |
 |---------------|--------------------|
 | IAM user | Through IAM, can be given these management hub roles: Cluster Administrator, Administrator, Operator, Editor, and Viewer. An IAM role is assigned to users or user groups when you add them to an IAM team. Team access to resources can be controlled by Kubernetes namespace. IAM users can also be given any of the Exchange roles below by using the **hzn exchange** CLI. |
 | Exchange root user | Has unlimited privilege in the exchange. This user is defined in the exchange config file. It can be disabled, if desired. |
@@ -54,5 +54,5 @@ There are four types of identities within {{site.data.keyword.ieam}}:
 | Exchange org admin user | Has unlimited exchange privilege within the organization. |
 | Exchange user | Can create exchange resources (nodes, services, patterns, policies) in the organization. Can update or delete resources owned by this user. Can read all services, patterns, and policies in the organization, and public services and patterns in other organizations. Can read nodes owned by this user. |
 | Exchange nodes | Can read its own node in the exchange, and read all services, patterns, and policies in the organization, and public service and patterns in other organizations. These are the only credentials that should be saved in the edge node, because they have the minimum privilege necessary to operate the edge node.|
-| Exchange agbots | Agbots in the IBM organization can read all nodes, services, patterns, and policies in all organizations. |
+| Exchange {{site.data.keyword.agbot}}s | {{site.data.keyword.agbot}}s in the IBM organization can read all nodes, services, patterns, and policies in all organizations. |
 {: caption="Table 1. RBAC roles" caption-side="top"}

--- a/docs/user_management/security_privacy.md
+++ b/docs/user_management/security_privacy.md
@@ -1,9 +1,9 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
- 
+years: 2021 - 2022
+lastupdated: "2022-03-10"
+
 ---
 
 {:new_window: target="blank"}
@@ -30,12 +30,12 @@ The {{site.data.keyword.ieam}} management hub and distributed agents communicate
 
 The control plane is implemented by three different software entities:
 * Open {{site.data.keyword.horizon}} agents
-* Open {{site.data.keyword.horizon}} agbots
+* Open {{site.data.keyword.horizon}} {{site.data.keyword.agbot}}s
 * Open {{site.data.keyword.horizon_exchange}}
 
-Open {{site.data.keyword.horizon}} agents and agbots are the primary actors within the control plane. The {{site.data.keyword.horizon_exchange}} facilitates discovery and secure communication between the agents and agbots. Together, they provide message-level protection by using an algorithm that is called Perfect Forward Secrecy.
+Open {{site.data.keyword.horizon}} agents and {{site.data.keyword.agbot}}s are the primary actors within the control plane. The {{site.data.keyword.horizon_exchange}} facilitates discovery and secure communication between the agents and {{site.data.keyword.agbot}}s. Together, they provide message-level protection by using an algorithm that is called Perfect Forward Secrecy.
 
-By default, agents and agbots communicate with the exchange via TLS 1.3. But TLS itself does not provide enough security. {{site.data.keyword.ieam}} encrypts every control message that flows between agents and agbots before it is sent over the network. Each agent and agbot generates a 2048-bit RSA key pair and publishes its public key in the exchange. The private key is stored in each actor's root-protected storage. Other actors in the system use the message receiver's public key to encrypt a symmetric key that is used to encrypt control plane messages. This ensures that only the intended receiver can decrypt the symmetric key; thus, the message itself. Perfect Forward Secrecy use in the control plane provides extra security, such as preventing man-in-the-middle attacks, which TLS does not prevent.
+By default, agents and {{site.data.keyword.agbot}}s communicate with the exchange via TLS 1.3. But TLS itself does not provide enough security. {{site.data.keyword.ieam}} encrypts every control message that flows between agents and {{site.data.keyword.agbot}}s before it is sent over the network. Each agent and {{site.data.keyword.agbot}} generates a 2048-bit RSA key pair and publishes its public key in the exchange. The private key is stored in each actor's root-protected storage. Other actors in the system use the message receiver's public key to encrypt a symmetric key that is used to encrypt control plane messages. This ensures that only the intended receiver can decrypt the symmetric key; thus, the message itself. Perfect Forward Secrecy use in the control plane provides extra security, such as preventing man-in-the-middle attacks, which TLS does not prevent.
 
 ### Agents
 {: #agents}
@@ -48,23 +48,23 @@ The agent is responsible for downloading and starting containerized workloads. T
 
 When a model is deployed to an edge node, the agent downloads the model and verfies the model's signature to ensure that it has not been tampered with in transit. The signature and verification key are created when the model is published to the management hub. The agent stores the model in root protected storage on the host. A credential is provided to each service when it is started by the agent. The service uses that credential to identify itself and enable access to the models that the service is allowed to access. Every model object in {{site.data.keyword.ieam}} indicates the list of services, which can access the model. Each service gets a new credential each time it is restarted by {{site.data.keyword.ieam}}. The model object is not encrypted by {{site.data.keyword.ieam}}. Because the model object is treated as a bag of bits by {{site.data.keyword.ieam}}, a service implementation is free to encrypt the model if necessary. For more about how to use the MMS, see [Model management details](../developing/model_management_details.md).
 
-### Agbots
+### {{site.data.keyword.agbot}}s
 {: #agbots}
 
-The {{site.data.keyword.ieam}} management hub contains several instances of an agbot, which are responsible for initiating the deployment of workloads to all the edge nodes registered with the management hub. Agbots periodically look at all the deployment policies and patterns that have been published to the exchange, ensuring that the services in those patterns and policies are deployed on all the correct edge nodes. When an agbot initiates a deployment request, it sends the request over the secure control plane. The deployment request contains everything the agent needs to verify the workload and its configuration, should the agent decide to accept the request. See [Agents](security_privacy.md#agents) for security details on what the agent does. The Agbot also directs the MMS where and when to deploy models. See [Agents](security_privacy.md#agents) for security details on how models are managed.
+The {{site.data.keyword.ieam}} management hub contains several instances of an {{site.data.keyword.agbot}}, which are responsible for initiating the deployment of workloads to all the edge nodes registered with the management hub. {{site.data.keyword.agbot}}s periodically look at all the deployment policies and patterns that have been published to the exchange, ensuring that the services in those patterns and policies are deployed on all the correct edge nodes. When an {{site.data.keyword.agbot}} initiates a deployment request, it sends the request over the secure control plane. The deployment request contains everything the agent needs to verify the workload and its configuration, should the agent decide to accept the request. See [Agents](security_privacy.md#agents) for security details on what the agent does. The {{site.data.keyword.agbot}} also directs the MMS where and when to deploy models. See [Agents](security_privacy.md#agents) for security details on how models are managed.
 
-A compromised agbot can attempt to propose malicious workload deployments, but the proposed deployment must meet the security requirements that are stated in the agent section. Even though the agbot initiates workload deployment it has no authority to create workloads and container configurations and therefore is unable to propose its own malicious workloads.
+A compromised {{site.data.keyword.agbot}} can attempt to propose malicious workload deployments, but the proposed deployment must meet the security requirements that are stated in the agent section. Even though the {{site.data.keyword.agbot}} initiates workload deployment it has no authority to create workloads and container configurations and therefore is unable to propose its own malicious workloads.
 
 ## {{site.data.keyword.horizon_exchange}}
 {: #exchange}
 
-{{site.data.keyword.horizon_exchange}} is a centralized, replicated, and load balanced REST API server. It functions as a shared database of metadata for users, organizations, edge nodes, published services, policies, and patterns. It also enables the distributed agents and agbots to deploy containerized workloads by providing the storage for the secure control plane, until the messages can be retrieved. The {{site.data.keyword.horizon_exchange}} is unable to read the control messages because it does not possess the private RSA key to decrypt the message. Thus a compromised {{site.data.keyword.horizon_exchange}} is incapable of spying on the control plane traffic. For more information on the role of the exchange, see [Overview of {{site.data.keyword.edge}}](../getting_started/overview_oh.md).
+{{site.data.keyword.horizon_exchange}} is a centralized, replicated, and load balanced REST API server. It functions as a shared database of metadata for users, organizations, edge nodes, published services, policies, and patterns. It also enables the distributed agents and {{site.data.keyword.agbot}}s to deploy containerized workloads by providing the storage for the secure control plane, until the messages can be retrieved. The {{site.data.keyword.horizon_exchange}} is unable to read the control messages because it does not possess the private RSA key to decrypt the message. Thus a compromised {{site.data.keyword.horizon_exchange}} is incapable of spying on the control plane traffic. For more information on the role of the exchange, see [Overview of {{site.data.keyword.edge}}](../getting_started/overview_oh.md).
 
 ## Privileged mode services
 {: #priv_services}
 On a host machine, some tasks can only be performed by an account with root access. The equivalent for containers is privileged mode. While containers generally do not need privileged mode on the host, there are some use cases where it is required. In {{site.data.keyword.ieam}} you have the ability to specify that an application service should be deployed with privileged process execution enabled. By default, it is disabled. You must explicitly enable it in the [deployment configuration](https://github.com/open-horizon/anax/blob/master/docs/deployment_string.md){:target="_blank"}{: .externalLink} of the respective Service Definition file for each service that needs to run in  this mode. And further, any node on which you want to deploy that service must also explicitly allow privileged mode containers. This ensures that node owners have some control over which services are executing on their edge nodes. For an example of how to enable privileged mode policy on an edge node, see [privileged node policy](https://github.com/open-horizon/anax/blob/master/cli/samples/privileged_node_policy.json){:target="_blank"}{: .externalLink}. If the service definition or one of its dependencies requires privileged mode, the node policy must also allow privileged mode, or else none of the services will not be deployed to the node. For an indepth discussion of privileged mode see [What is privileged mode and do I need it?](https://wiki.lfedge.org/pages/viewpage.action?pageId=44171856){:target="_blank"}{: .externalLink}.
 
-## Denial-of-service attack 
+## Denial-of-service attack
 {: #denial}
 
 The {{site.data.keyword.ieam}} management hub is a centralized service. Centralized services in typical cloud based environments are generally vulnerable to denial-of-service attacks. The agent requires a connection only when it is first registered to the hub or when it is negotiating the deployment of a workload. At all other times, the agent continues to operate normally even while disconnected from the {{site.data.keyword.ieam}} management hub.  This ensures that the {{site.data.keyword.ieam}} agent remains active on edge node even if the management hub is under attack.

--- a/docs/user_management/security_privacy.md
+++ b/docs/user_management/security_privacy.md
@@ -30,7 +30,7 @@ The {{site.data.keyword.ieam}} management hub and distributed agents communicate
 
 The control plane is implemented by three different software entities:
 * Open {{site.data.keyword.horizon}} agents
-* Open {{site.data.keyword.horizon}} {{site.data.keyword.agbot}}s
+* Open {{site.data.keyword.horizon_agbots}}
 * Open {{site.data.keyword.horizon_exchange}}
 
 Open {{site.data.keyword.horizon}} agents and {{site.data.keyword.agbot}}s are the primary actors within the control plane. The {{site.data.keyword.horizon_exchange}} facilitates discovery and secure communication between the agents and {{site.data.keyword.agbot}}s. Together, they provide message-level protection by using an algorithm that is called Perfect Forward Secrecy.

--- a/docs/using_edge_services/service_rollbacks.md
+++ b/docs/using_edge_services/service_rollbacks.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2021 - 2022
+lastupdated: "2022-03-10"
 
 ---
 
@@ -34,7 +34,7 @@ As explained in the [Developing edge services with {{site.data.keyword.edge_notm
 ## Updating rollback settings in pattern or deployment policy
 {: #updating_rollback_settings}
 
-A new edge service specifies its version number in the `version` field of the service definition.  
+A new edge service specifies its version number in the `version` field of the service definition.
 
 Patterns or deployment policies determine which services are deployed to which edge nodes. To use edge service rollback capabilities, you need to add the reference for your new service version number in the **serviceVersions** section in either the pattern or deployment policy configuration files.
 
@@ -43,7 +43,7 @@ When an edge service is deployed to an edge node as a result of a pattern or pol
 For example:
 
 ```json
- "serviceVersions": 
+ "serviceVersions":
 [
  {
    "version": "2.3.1",
@@ -73,26 +73,25 @@ For example:
 ```
 {: codeblock}
 
-Additional variables are provided in the priority section. The `priority_value` property sets the order of which service version to try first, in practical terms a lower number means higher priority. The `retries` variable value defines the number of times Horizon will attempt to start this service version within the time frame that is specified by `retry_durations` before rolling back to the next highest priority version. The `retry_durations` variable defines the specific time interval in seconds. For example, three service failures over the course of a month might not warrant rolling the service back to an earlier version, but 3 failures within 5 mins might be an indication that there is something wrong with the new service version.
+Additional variables are provided in the priority section. The `priority_value` property sets the order of which service version to try first, in practical terms a lower number means higher priority. The `retries` variable value defines the number of times Horizon will attempt to start this service version within the time frame that is specified by `retry_durations` before rolling back to the next highest priority version. The `retry_durations` variable defines the specific time interval in seconds. For example, three service failures over the course of a month might not warrant rolling the service back to an earlier version, but 3 failures within 5 mins might be an indication that there is something wrong with the new service version.
 
 Next, either republish your deployment pattern or update the deployment policy with the **serviceVersion** section changes in the Horizon exchange.
 
-Notice that you can also verify the compatibility of the deployment policy or pattern settings updates with the CLI `deploycheck` command. To view more details, issue: 
+Notice that you can also verify the compatibility of the deployment policy or pattern settings updates with the CLI `deploycheck` command. To view more details, issue:
 
 ```bash
 hzn deploycheck -h
 ```
 {: codeblock}
 
-The {{site.data.keyword.ieam}} agbots quickly detect the deployment pattern or deployment policy changes. The agbots then reach out to each agent whose edge node is either registered to run the deployment pattern or is compatible with the updated deployment policy. The agbot and the agent coordinate to download the new containers, stop and remove the old containers, and start the new containers.
+The {{site.data.keyword.ieam}} {{site.data.keyword.agbot}}s quickly detect the deployment pattern or deployment policy changes. The {{site.data.keyword.agbot}}s then reach out to each agent whose edge node is either registered to run the deployment pattern or is compatible with the updated deployment policy. The {{site.data.keyword.agbot}} and the agent coordinate to download the new containers, stop and remove the old containers, and start the new containers.
 
 As a result, your edge nodes that are either registered to run the updated deployment pattern or are compatible with the deployment policy quickly runs the new edge service version with the top priority value, regardless of where the edge node is geographically located.
- 
 
 ## Viewing progress of new service version being rolled out
 {: #viewing_rollback_progress}
 
-Repeatedly query the device agreements until the `agreement_finalized_time` and `agreement_execution_start_time` fields are filled in: 
+Repeatedly query the device agreements until the `agreement_finalized_time` and `agreement_execution_start_time` fields are filled in:
 
 ```bash
 hzn agreement list


### PR DESCRIPTION
# Pull Request Template

## Description

Modify all of the documentation markdown files that use `Agbot` as prose.  Substitute the usage of  `agbot`, `AgBot`, `Agbot` with a `Agbot`  keyword.  Skip the few use cases where agbot is used as part of the `hzn agbot` command or part of a OpenShift container name.

The keyword will not be translated.  The Agbot keyword is a "proper noun" so capitalized.  The documentation was very inconsistent in usage.

Fixes #204 

## Type of change

- [x ] This change required a documentation update
