### PR TITLE
Issue-245: Excluded two files

### DIFF
--- a/.github/workflows/orphan_pages_checker.yml
+++ b/.github/workflows/orphan_pages_checker.yml
@@ -31,7 +31,7 @@ jobs:
                   kill -15 $pid
                   printf "Killed the Server\n"
                   printf "Finding Orphan Pages\n"
-                  diff -qr 127.0.0.1\:4000/ ./_site | grep Only | grep .html
+                  diff -qr 127.0.0.1\:4000/ ./_site | grep Only | grep .html | grep -v 404.html | grep -v dir.html
             - name: Creating issue
               uses: JasonEtco/create-an-issue@v2.4.0
               env:


### PR DESCRIPTION
Signed-off-by: Joe Pearson <joe.pearson@us.ibm.com>

# Pull Request Template

## Description

The Orphan Page Checker GHA does not contain an exclude list.  As a temporary fix, I've taken the diff statement that compares the site links to the physical files and piped it through a grep exclusion for the two exceptions.  Clearly, this approach is not scalable long-term.

Fixes # Issue #245 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have not found a way to test GHAs.

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->

@johnwalicki If you're OK with this approach and I haven't made a mistake, please review and approve.