### PR TITLE
Issue-247: document_conventions.md lint fixes

### DIFF
--- a/docs/getting_started/document_conventions.md
+++ b/docs/getting_started/document_conventions.md
@@ -2,7 +2,7 @@
 
 copyright:
 years: 2020 - 2022
-lastupdated: "2022-03-17"
+lastupdated: "2022-05-05"
 
 ---
 
@@ -15,6 +15,7 @@ lastupdated: "2022-03-17"
 {:childlinks: .ullinks}
 
 # Conventions used in this document
+
 {: #document_conventions}
 
 This document uses content conventions to convey specific meaning.  
@@ -25,16 +26,15 @@ Replace the variable content that is shown in < > with values specific to your n
 
 ### Example
 
-  ```
+  ```sh
   hzn key create "<companyname>" "<youremailaddress>"
   ```
   {: codeblock}
-   
+
 ## Literal strings
 
 Content that you see on the management hub or in code is a literal string. This content is shown as **bold** text.
-   
- ### Example
-   
- If you examine the `service.sh` code, you see that it uses these, and other configuration variables to control its behavior. **PUBLISH** controls if the code attempts to send messages to IBM Event Streams. **MOCK** controls if service.sh attempts to contact the REST APIs and its dependent services (cpu and gps) or if `service.sh` creates fake data.
-  
+
+### Example
+
+If you examine the `service.sh` code, you see that it uses these, and other configuration variables to control its behavior. **PUBLISH** controls if the code attempts to send messages to IBM Event Streams. **MOCK** controls if service.sh attempts to contact the REST APIs and its dependent services (cpu and gps) or if `service.sh` creates fake data.


### PR DESCRIPTION
## Description

I noticed that there is a typo in the document_conventions.md that caused the ### Examples header to render as markdown instead of a subheader in the html file.

The fix was to remove a leading space. I also fixed several other lint warnings on this page.

Fixes #247 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.
