### PR TITLE
Issue-263: Add ppc64le keyword

### DIFF
--- a/_data/keyword.yml
+++ b/_data/keyword.yml
@@ -84,6 +84,8 @@ linux_bit:
   Linux&reg; x86_64
 linux_bit_notm:
   Linux x86_64
+linux_ppc64le_notm:
+  Linux ppc64le
 mac_notm:
   Mac
 mac:


### PR DESCRIPTION
Signed-off-by: John Walicki <johnwalicki@gmail.com>

## Description

Add the `linux_ppc64le_notm` keyword substitution for `Linux ppc64le` to `_data/keyword.yml`

Fixes #263

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Add the new Linux ppc64le keyword stanza to `_data/keyword.yml` file
View the  ppc64le section in https://open-horizon.github.io/docs/installing/adding_devices.html
...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.
