### PR TITLE
Issue 3268 - podman netavark

### DIFF
--- a/docs/installing/adding_devices.md
+++ b/docs/installing/adding_devices.md
@@ -27,7 +27,7 @@ The following instructions guide you through the process of installing the requi
 - x86_64
   - {{site.data.keyword.linux_bit_notm}} devices or virtual machines that run Ubuntu 22.x (jammy), Ubuntu 20.x (focal), Ubuntu 18.x (bionic), Debian 10 (buster), Debian 9 (stretch)
   - {{site.data.keyword.rhel}} 8.1, 8.2, 8.3, 8.4, 8.5 and 8.6
-  - {{site.data.keyword.Fedora} Workstation 32, 36
+  - {{site.data.keyword.fedora}} Workstation 32, 36
   - CentOS 8.1, 8.2, 8.3, 8.4 and 8.5
   - SuSE 15 SP2
 - ppc64le
@@ -42,10 +42,10 @@ The following instructions guide you through the process of installing the requi
 
 **Notes**:
 
-- Installation of edge devices with Fedora or SuSE is only supported by the [Advanced manual agent installation and registration](../installing/advanced_man_install.md) method.
-- CentOS and {{site.data.keyword.rhel}} on {{site.data.keyword.ieam}} {{site.data.keyword.version}} only support Docker as a container engine.
+- Installation of edge devices with {{site.data.keyword.fedora}} or SuSE is only supported by the [Advanced manual agent installation and registration](../installing/advanced_man_install.md) method.
+- CentOS and {{site.data.keyword.rhel}} 8.5 or earlier on {{site.data.keyword.ieam}} {{site.data.keyword.version}} only support Docker as a container engine.
 - While {{site.data.keyword.ieam}} {{site.data.keyword.version}} supports running {{site.data.keyword.rhel}} 8.x with Docker, it is officially unsupported by {{site.data.keyword.rhel}}.
-- {{site.data.keyword.ieam}} {{site.data.keyword.version}} supports Podman 4.x on {{site.data.keyword.rhel}} 8.6 and Fedora Workstation.
+- {{site.data.keyword.ieam}} {{site.data.keyword.version}} supports Podman 4.x on {{site.data.keyword.rhel}} 8.6 and {{site.data.keyword.fedora}} 36 Workstation.
 
 ## Sizing
 {: #size}

--- a/docs/installing/advanced_man_install.md
+++ b/docs/installing/advanced_man_install.md
@@ -54,20 +54,39 @@ Follow these steps:
    ```
    {: codeblock}
 
-2. Query the Docker or Podman version to check whether it is recent enough:
+2. Query the OCI container runtime version to check whether it is recent enough:
 
-   ```bash
-   docker --version
-   ```
-   {: codeblock}
+   a. Docker
 
-      If docker is not installed, or the version is older than `18.06.01`, install the most recent version of Docker. Alternatively, Podman v4 or greater is also supported.
+      ```bash
+      docker --version
+      ```
+      {: codeblock}
 
-   ```bash
-   curl -fsSL get.docker.com | sh
-   docker --version
-   ```
-   {: codeblock}
+      If docker is not installed, or the version is older than `18.06.01`, install the most recent version of Docker.
+
+      ```bash
+      curl -fsSL get.docker.com | sh
+      docker --version
+      ```
+      {: codeblock}
+
+   b. Podman
+
+      ```bash
+      podman --version
+      ```
+      {: codeblock}
+
+   If podman is not installed, or the version is older than `4.0`, install the most recent version of Podman.
+
+      ```bash
+      dnf install podman podman-docker netavark
+      podman --version
+      ```
+      {: codeblock}
+
+   Switch the network stack from CNI to Netavark. The {{site.data.keyword.horizon}} agent requires the network backend to be configured to use netavark instead of cni so that the agent can set up networking scenarios such as dependent services between containers.  Follow the steps in the Red Hat documentation [switching the network stack ](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index#proc_switching-the-network-stack-from-cni-to-netavark_assembly_setting-container-network-modes){:target="_blank"}{: .externalLink} chapter.
 
 3. Install the Horizon packages that you copied to this edge device:
 
@@ -92,7 +111,7 @@ Follow these steps:
    ```
    {: codeblock}
 
-5. Point your edge device horizon agent to your {{site.data.keyword.edge_notm}} cluster by populating `/etc/default/horizon` with the correct information:
+5. Point your edge device {{site.data.keyword.horizon}} agent to your {{site.data.keyword.edge_notm}} cluster by populating `/etc/default/horizon` with the correct information:
 
    ```bash
    sed -i.bak -e "s|^HZN_EXCHANGE_URL=[^ ]*|HZN_EXCHANGE_URL=${HZN_EXCHANGE_URL}|g" -e "s|^HZN_FSS_CSSURL=[^ ]*|HZN_FSS_CSSURL=${HZN_FSS_CSSURL}|g" /etc/default/horizon
@@ -195,7 +214,7 @@ Follow these steps:
   ```
   {: codeblock}
 
-4. When you are installing a **new device**, this step is not necessary. But if you installed and started the horizon container on this machine previously, stop it now by running:
+4. When you are installing a **new device**, this step is not necessary. But if you installed and started the {{site.data.keyword.horizon}} container on this machine previously, stop it now by running:
 
   ```bash
   horizon-container stop
@@ -209,7 +228,7 @@ Follow these steps:
   ```
   {: codeblock}
 
-6. Point your edge device horizon agent to your {{site.data.keyword.edge_notm}} cluster by populating `/etc/default/horizon` with the correct information:
+6. Point your edge device {{site.data.keyword.horizon}} agent to your {{site.data.keyword.edge_notm}} cluster by populating `/etc/default/horizon` with the correct information:
 
   ```bash
   sudo mkdir -p /etc/default


### PR DESCRIPTION
Signed-off-by: John Walicki <johnwalicki@gmail.com>

## Description

Fix a Fedora keyword typo, reformat the advanced install steps to split out Docker and Podman.
Add additional Podman netavark network backend steps.

Fixes #266  and https://github.com/open-horizon/anax/issues/3268

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Visit these pages:
- https://open-horizon.github.io/docs/installing/advanced_man_install.html
- https://open-horizon.github.io/docs/installing/adding_devices.html#rhel8

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.
