### PR TITLE
Issue-275: added conditional logic, user management links to remove orphan page issue

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2021 - 2022
+lastupdated: "2022-06-03"
 title: APIs
 description: ""
 ---
@@ -27,7 +27,12 @@ For most users, the `hzn` command line interface (CLI) tool, which calls these A
 
 * [Agent API](agent_api.md)
 * [Agbot API](agbot_api.md)
+{% if site.data.keyword.edge_notm == "Open Horizon" %}
+* [Agbot User API](../api/agbot_secure_api.html)
+* [Exchange API](../api/exchange_swagger.html)
+{% else %}
 * [Agbot User API](agbot_secure_api.json)
 * [Exchange API](exchange_swagger.json)
+{% endif %}
 * [MMS API](mms_swagger.html)
 * [SDO API](sdo_swagger.html)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -26,13 +26,10 @@ The {{site.data.keyword.ieam}} REST APIs are documented within the {{site.data.k
 For most users, the `hzn` command line interface (CLI) tool, which calls these APIs, is sufficient for completing most tasks. If you do use this tool, direct use of the API is unnecessary.
 
 * [Agent API](agent_api.md)
-* [Agbot API](agbot_api.md)
-{% if site.data.keyword.edge_notm == "Open Horizon" %}
+* [Agbot API](agbot_api.md){% if site.data.keyword.edge_notm == "Open Horizon" %}
 * [Agbot User API](../api/agbot_secure_api.html)
-* [Exchange API](../api/exchange_swagger.html)
-{% else %}
+* [Exchange API](../api/exchange_swagger.html){% else %}
 * [Agbot User API](agbot_secure_api.json)
-* [Exchange API](exchange_swagger.json)
-{% endif %}
+* [Exchange API](exchange_swagger.json){% endif %}
 * [MMS API](mms_swagger.html)
 * [SDO API](sdo_swagger.html)

--- a/docs/user_management/security.md
+++ b/docs/user_management/security.md
@@ -2,7 +2,7 @@
 
 copyright:
 years: 2020 - 2022
-lastupdated: "2022-03-17"
+lastupdated: "2022-06-03"
 
 ---
 
@@ -22,6 +22,9 @@ lastupdated: "2022-03-17"
 * [Security and privacy](security_privacy.md)
 * [Role-based access control](rbac.md)
 * [{{site.data.keyword.edge_notm}} considerations for GDPR readiness](gdpr.md)
+* [Certificates](../user_management/certificates.md)
+* [Disaster recovery](../user_management/disaster_recovery.md)
+* [Monitoring management hub components](../user_management/monitoring_infrastructure.md)
 {: childlinks}
 
 For more information about creating workload signing keys if you do not already have your own RSA keys, see [Preparing to create an edge service](../developing/service_containers.md). Use these keys to sign services when you publish them to the exchange and enable the {{site.data.keyword.ieam}} agent to verify that it started a valid workload.


### PR DESCRIPTION
Signed-off-by: Joe Pearson <joe.pearson@us.ibm.com>

# Pull Request Template

## Description

Added links for three new "user management" pages to the services.html page in that folder, since it appeared to be the index page.

Changes API links from JSON to interactive Swagger pages **only** for Open Horizon docs using Liquid Templating conditional logic: https://shopify.github.io/liquid/tags/control-flow/

Fixes #275 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran locally on doc server.

```
make init
make dev
make build
make run
```

open http://localhost:4000/docs/user_management/security.html, see "certificates", "disaster recovery", "monitoring" links.
open http://localhost:4000/docs/api/index.html, see "Agbot User API" and "Exchange API" links.

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [X] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->

@johnwalicki and @Rene-Ch1 let me know if you have any questions.