### PR TITLE
Issue 219: Sync Docs

### DIFF
--- a/docs/cli/hzn_cli.md
+++ b/docs/cli/hzn_cli.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2022
+lastupdated: "2022-06-14"
 title: hzn CLI
 description: ""
 ---
@@ -18,9 +18,9 @@ description: ""
 # Installing the hzn CLI
 {: #using_hzn_cli}
 
-When you install the {{site.data.keyword.ieam}} agent software on an edge node, the **hzn** CLI is automatically installed. But you can also install the **hzn** CLI without the agent. For example, an edge administrator might want to query the {{site.data.keyword.ieam}} exchange or an edge developer might want to test with **hzn dev** commands.
+The `hzn` command is the {{site.data.keyword.ieam}} command line interface. When you install the {{site.data.keyword.ieam}} agent software on an edge node, the `hzn` CLI is automatically installed. But you can also install the `hzn` CLI without the agent. For example, an edge administrator might want to query the {{site.data.keyword.ieam}} exchange or an edge developer might want to test with `hzn` commands, without the full agent.
 
-1. Get the **agentInstallFiles-&lt;edge-device-type&gt;.tar.gz** file from your management hub administrator, where **&lt;edge-device-type&gt;** matches the host where you installing **hzn**. They were already created in [Gather the necessary information and files for edge devices](../hub/gather_files.md#prereq_horizon). Copy this file to the host where you are installing **hzn**.
+1. Get the **agentInstallFiles-&lt;edge-device-type&gt;.tar.gz** file from your management hub administrator, where **&lt;edge-device-type&gt;** matches the host where you installing `hzn`. They were already created in [Gather the necessary information and files for edge devices](../hub/gather_files.md#prereq_horizon). Copy this file to the host where you are installing **hzn**.
 
 2. Set the file name in an environment variable for subsequent steps:
 
@@ -29,28 +29,37 @@ When you install the {{site.data.keyword.ieam}} agent software on an edge node, 
    ```
    {: codeblock}
 
-3. Extract the horizon CLI package from the tar file:
+3. Extract the `horizon_cli` package from the `agentInstallFiles-<edge-device-type>.tar.gz` tar file:
 
    ```bash
    tar -zxvf $AGENT_TAR_FILE 'horizon-cli*'
    ```
    {: codeblock}
 
-   * Confirm that the package version is the same as the device agent listed in [Components](../getting_started/components.md).
+4. Install the `horizon-cli` package:
 
-4. Install the **horizon-cli** package:
+   - Confirm that the package version is the same as the device agent listed in [Components](../getting_started/components.md).
 
-   * On a debian-based distro:
+   - On a debian-based distro:
 
      ```bash
-     sudo apt update && sudo apt install horizon-cli*.deb
+     sudo apt update && sudo apt install ./horizon-cli*.deb
      ```
      {: codeblock}
 
-   * On {{site.data.keyword.macOS_notm}}:
+   - On a RPM-based distro:
 
      ```bash
+     sudo yum install ./horizon-cli*.rpm
+     ```
+     {: codeblock}
+
+   - On {{site.data.keyword.macOS_notm}}:
+
+     ```bash
+     sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain horizon-cli.crt
      sudo installer -pkg horizon-cli-*.pkg -target /
+     pkgutil --pkg-info com.github.open-horizon.pkg.horizon-cli   # confirm version installed
      ```
      {: codeblock}
 
@@ -58,16 +67,23 @@ When you install the {{site.data.keyword.ieam}} agent software on an edge node, 
 
 ## Uninstalling the hzn CLI
 
-If you want to remove the **horizon-cli** package from a host:
+If you want to remove the `horizon-cli` package from a host:
 
-* Uninstall **horizon-cli** from a debian-based distro:
+- Uninstall `horizon-cli` from a debian-based distro:
 
   ```bash
   sudo apt-get remove horizon-cli
   ```
   {: codeblock}
 
-* Or uninstall **horizon-cli** from {{site.data.keyword.macOS_notm}}:
+- Uninstall `horizon-cli` from an RPM-based distro:
+
+  ```bash
+  sudo yum remove horizon-cli
+  ```
+  {: codeblock}
+
+- Or uninstall `horizon-cli` from {{site.data.keyword.macOS_notm}}:
 
   ```bash
   sudo horizon-cli-uninstall.sh

--- a/docs/developing/developingstart_example.md
+++ b/docs/developing/developingstart_example.md
@@ -2,7 +2,7 @@
 
 copyright:
 years: 2020 - 2022
-lastupdated: "2022-03-17"
+lastupdated: "2022-06-14"
 title: Creating your own hello world edge service
 description: ""
 ---
@@ -15,6 +15,9 @@ description: ""
 {:child: .link .ulchildlink}
 {:childlinks: .ullinks}
 
+# Creating your own hello world edge service
+{: #dev_start_ex}
+
 The following example uses a simple `Hello World` service to help you learn more about developing for {{site.data.keyword.edge_notm}} ({{site.data.keyword.ieam}}). With this example, you develop a single edge service that supports three hardware architectures and uses the {{site.data.keyword.horizon}} development tools.
 {:shortdesc}
 
@@ -22,7 +25,8 @@ The following example uses a simple `Hello World` service to help you learn more
 {: #dev_start_ex_begin}
 
 Complete the prerequisite steps in [Preparing to create an edge service](service_containers.md). As a result, these environment variables should be set, these commands should be installed, and these files should exist:
-```
+
+```bash
 echo "HZN_ORG_ID=$HZN_ORG_ID, HZN_EXCHANGE_USER_AUTH=$HZN_EXCHANGE_USER_AUTH, DOCKER_HUB_ID=$DOCKER_HUB_ID"
 which git jq make
 ls ~/.hzn/keys/service.private.key ~/.hzn/keys/service.public.pem
@@ -38,4 +42,4 @@ This example is part of the [{{site.data.keyword.horizon_open}} ](https://github
 ## What to do next
 {: #dev_start_ex_what_next}
 
-* Try the other edge service examples at [Developing edge services with {{site.data.keyword.edge_notm}}](developing.md).
+- Try the other edge service examples at [Developing an edge service with {{site.data.keyword.edge_notm}}](developing.md).

--- a/docs/getting_started/document_conventions.md
+++ b/docs/getting_started/document_conventions.md
@@ -2,7 +2,7 @@
 
 copyright:
 years: 2020 - 2022
-lastupdated: "2022-05-05"
+lastupdated: "2022-06-14"
 
 ---
 
@@ -18,7 +18,7 @@ lastupdated: "2022-05-05"
 
 {: #document_conventions}
 
-This document uses content conventions to convey specific meaning.  
+This document uses content conventions to convey specific meaning.
 
 ## Command conventions
 
@@ -26,7 +26,7 @@ Replace the variable content that is shown in < > with values specific to your n
 
 ### Example
 
-  ```sh
+  ```bash
   hzn key create "<companyname>" "<youremailaddress>"
   ```
   {: codeblock}

--- a/docs/getting_started/release_notes.md
+++ b/docs/getting_started/release_notes.md
@@ -2,7 +2,7 @@
 
 copyright:
 years: 2020 - 2022
-lastupdated: "2022-03-17"
+lastupdated: "2022-06-14"
 
 ---
 
@@ -17,10 +17,10 @@ lastupdated: "2022-03-17"
 # Release notes
 {: #releasenotes}
 
-The following sections document new features and changes that are included for this release of {{site.data.keyword.edge_notm}} ({{site.data.keyword.ieam}}). Unless otherwise noted, all changes are compatible with earlier releases and are automatically and transparently available to all new and existing {{site.data.keyword.ieam}} users.
+The following sections document new features, restrictions, and changes that are included for this release of {{site.data.keyword.edge_notm}} ({{site.data.keyword.ieam}}). Unless otherwise noted, all changes are compatible with earlier releases and are automatically and transparently available to all new and existing {{site.data.keyword.ieam}} users.
 
 - {: child} [What's new](whats_new.md)
-- {: child} [Known issues and limitations](known_issues.md)
+- {: child} [Known issues and limitations for {{site.data.keyword.ieam}}](known_issues.md)
 - {: child} [Accessibility features](accessibility.md)
 - {: child} [Supported languages](languages.md)
 - {: child} [Conventions used in this document](document_conventions.md)

--- a/docs/installing/edge_cluster_agent.md
+++ b/docs/installing/edge_cluster_agent.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021
-lastupdated: "2021-02-20"
+years: 2022
+lastupdated: "2022-06-14"
 
 ---
 
@@ -47,9 +47,9 @@ This content describes how to install the {{site.data.keyword.ieam}} agent on yo
 2. If you have not completed the steps in [Prepare for setting up edge nodes](../hub/prepare_for_edge_nodes.md), do that now. This process creates an API key, locates some files, and gathers environment variable values that are needed when you set up edge nodes. Set the same environment variables on this edge cluster:
 
   ```bash
-  export HZN_EXCHANGE_USER_AUTH=iamapikey:<api-key>
+  export HZN_EXCHANGE_USER_AUTH=iamapikey:<api-key>
   export HZN_ORG_ID=<your-exchange-organization>
-  export HZN_FSS_CSSURL=https://<ieam-management-hub-ingress>/edge-css/
+  export HZN_FSS_CSSURL=https://<management-hub-ingress>/edge-css/
   ```
   {: codeblock}
 
@@ -60,7 +60,7 @@ This content describes how to install the {{site.data.keyword.ieam}} agent on yo
    ```
    {: codeblock}
 
-4. Set the storage class that you want the agent use to either a built-in storage class or one you created. For example:
+4. Set the storage class that you want the agent to use - either a built-in storage class or one that you created. For example:
 
    ```bash
    export EDGE_CLUSTER_STORAGE_CLASS=rook-ceph-cephfs-internal
@@ -78,7 +78,7 @@ This content describes how to install the {{site.data.keyword.ieam}} agent on yo
    ```
    {: codeblock}
 
-   **Note:** The {{site.data.keyword.ieam}} agent image is stored in the local edge cluster registry because the edge cluster Kubernetes needs ongoing access to it, in case it needs to restart it or move it to another pod.
+   **Note**: The {{site.data.keyword.ieam}} agent image is stored in the local edge cluster registry because the edge cluster Kubernetes needs ongoing access to it, in case it needs to restart it or move it to another pod.
 
 7. Copy the **agent-install.sh** script to your new edge cluster.
 
@@ -89,7 +89,7 @@ This content describes how to install the {{site.data.keyword.ieam}} agent on yo
    ```
    {: codeblock}
 
-   **Notes:**
+   **Notes**:
    * To see all of the available flags, run: **./agent-install.sh -h**
    * If an error causes **agent-install.sh** to fail, correct the error and run **agent-install.sh** again. If that does not work, run **agent-uninstall.sh** (see [Removing agent from edge cluster](../using_edge_services/removing_agent_from_cluster.md)) before running **agent-install.sh** again.
 
@@ -126,7 +126,7 @@ This content describes how to install the {{site.data.keyword.ieam}} agent on [k
 2. If you have not completed the steps in [Prepare for setting up edge nodes](../hub/prepare_for_edge_nodes.md), do that now. This process creates an API key, locates some files, and gathers environment variable values that are needed when setting up edge nodes. Set the same environment variables on this edge cluster:
 
   ```bash
-  export HZN_EXCHANGE_USER_AUTH=iamapikey:<api-key>
+  export HZN_EXCHANGE_USER_AUTH=iamapikey:<api-key>
   export HZN_ORG_ID=<your-exchange-organization>
   export HZN_FSS_CSSURL=https://<ieam-management-hub-ingress>/edge-css/
   ```
@@ -176,7 +176,7 @@ This content describes how to install the {{site.data.keyword.ieam}} agent on [k
    ```
    {: codeblock}
 
-   **Notes:**
+   **Notes**:
    * To see all of the available flags, run: **./agent-install.sh -h**
    * If an error occurs causing **agent-install.sh** to not complete successfully, correct the error that is displayed, and run **agent-install.sh** again. If that does not work, run **agent-uninstall.sh** (see [Removing agent from edge cluster](../using_edge_services/removing_agent_from_cluster.md)) before running **agent-install.sh** again.
 
@@ -229,7 +229,7 @@ Setting node policy on this edge cluster can cause deployment policies to deploy
    ```
    {: codeblock}
 
-   **Note:**
+   **Note**:
    * Because the real **hzn** command is running inside the agent container, for any `hzn` commands that require an input file, you need to pipe the file into the command so its content will be transferred into the container.
 
 4. After a minute, check for an agreement and the running edge operator and service containers:

--- a/docs/installing/sdo.md
+++ b/docs/installing/sdo.md
@@ -2,7 +2,7 @@
 
 copyright:
 years: 2020 - 2022
-lastupdated: "2022-03-17"
+lastupdated: "2022-06-14"
 
 ---
 
@@ -54,7 +54,7 @@ Before you purchase SDO-enabled edge devices, you can test SDO support in {{site
    ```bash
    export HZN_ORG_ID=<exchange-org>
    export HZN_EXCHANGE_USER_AUTH=iamapikey:<api-key>
-   export HZN_SDO_SVC_URL=https://<ieam-mgmt-hub-ingress>/edge-sdo-ocs/api
+   export HZN_SDO_SVC_URL=https://<mgmt-hub-ingress>/edge-sdo-ocs/api
    export HZN_MGMT_HUB_CERT_PATH=<path-to-mgmt-hub-self-signed-cert>
    export CURL_CA_BUNDLE=$HZN_MGMT_HUB_CERT_PATH
    ```
@@ -75,7 +75,7 @@ If you have purchased SDO-enabled devices and want to incorporate them into your
       ```bash
       export HZN_ORG_ID=<exchange-org>
       export HZN_EXCHANGE_USER_AUTH=iamapikey:<api-key>
-      export HZN_SDO_SVC_URL=https://<ieam-mgmt-hub-ingress>/edge-sdo-ocs/api
+      export HZN_SDO_SVC_URL=https://<mgmt-hub-ingress>/edge-sdo-ocs/api
       export HZN_MGMT_HUB_CERT_PATH=<path-to-mgmt-hub-self-signed-cert>
       export CURL_CA_BUNDLE=$HZN_MGMT_HUB_CERT_PATH
       ```
@@ -84,7 +84,7 @@ If you have purchased SDO-enabled devices and want to incorporate them into your
 
 2. [Log in to the {{site.data.keyword.ieam}} management console](../console/accessing_ui.md).
 
-3. On the **Nodes** tab, click **Add node**. 
+3. On the **Nodes** tab, click **Add node**.
 
    Enter the information necessary to create a private ownership key in the SDO service and download the corresponding public key.
 


### PR DESCRIPTION
Signed-off-by: John Walicki <johnwalicki@gmail.com>

## Description

Partial sync of the hzn_cli.md between the Open Horizon Docs and the IBM Edge Application Manager docs.  I converged them to the extent possible. Closer but not 100%

I also took the opportunity to sync several other Open Horizon documents with some of the IEAM 4.3.3 documentation changes.

Fixes #219 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

View these rendered pages on the OH docs site:
- https://open-horizon.github.io/docs/cli/hzn_cli.html
- https://open-horizon.github.io/docs/getting_started/release_notes.html
- https://open-horizon.github.io/docs/getting_started/document_conventions.html
- https://open-horizon.github.io/docs/installing/edge_cluster_agent.html
- https://open-horizon.github.io/docs/installing/sdo.html
...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.