### PR TITLE
Issue #333: Fix broken link for agent-install in anax doc

### DIFF
--- a/docs/anax/docs/node_management.md
+++ b/docs/anax/docs/node_management.md
@@ -5,4 +5,4 @@ Node management policy (NMP) enables node administrators to remotely configure s
 ## Agent Auto Upgrade
 
 The agent auto upgrade section of node management policy enables nodes to update any combination of their configuration, certificate, and agent software.
-- `configuration`: This contains information about the management hub the node is registered to. See [here](../agent-install/README.md#configuration-file) for the expected contents of this file.
+- `configuration`: This contains information about the management hub the node is registered to. See [here](https://github.com/open-horizon/anax/blob/master/agent-install/README.md) for the expected contents of this file.

--- a/docs/anax/docs/node_management.md
+++ b/docs/anax/docs/node_management.md
@@ -5,4 +5,4 @@ Node management policy (NMP) enables node administrators to remotely configure s
 ## Agent Auto Upgrade
 
 The agent auto upgrade section of node management policy enables nodes to update any combination of their configuration, certificate, and agent software.
-- `configuration`: This contains information about the management hub the node is registered to. See [here](https://github.com/open-horizon/anax/blob/master/agent-install/README.md) for the expected contents of this file.
+- `configuration`: This contains information about the management hub the node is registered to. See [here](https://github.com/open-horizon/anax/blob/master/agent-install/README.md#configuration-file) for the expected contents of this file.


### PR DESCRIPTION
# Pull Request Template

## Description

Fix broken link related to the agent install in the anax documentation. The fix involves providing a hard link to the missing page.

Fixes #333 (partial)

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Visit

1. https://open-horizon.github.io/docs/anax/docs/node_management.html
2. Click on the link in configuration under the 'Agent Auto Upgrade' section to open https://github.com/open-horizon/anax/blob/master/agent-install/README.md#configuration-file

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
