### PR TITLE
Issue-416: added install instructions for just the agent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
       jemoji (= 0.12.0)
       kramdown (= 2.3.2)
       kramdown-parser-gfm (= 1.1.0)
-      liquid (= 4.0.3)
+      liquid (= 4.0.4)
       mercenary (~> 0.3)
       minima (= 2.5.1)
       nokogiri (>= 1.13.6, < 2.0)
@@ -99,7 +99,7 @@ GEM
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
       kramdown (>= 1.17, < 3)
-      liquid (~> 4.0)
+      liquid (~> 4.0.4)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
@@ -207,7 +207,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
+    liquid (4.0.4)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -275,4 +275,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.4.3
+   2.4.7

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ show-args:
 
 # make init: install and update all dependencies. run once before using tools each day
 init:
-	$(GEM) update --system 3.4.3
+	$(GEM) update --system 3.4.7
 	$(GEM) install bundler
 	$(BUNDLE) update --bundler
 	$(BUNDLE) config set --local deployment 'true'

--- a/quick-start.md
+++ b/quick-start.md
@@ -13,13 +13,13 @@ has_toc: false
 
 ### Overview
 
-Open Horizon is a middleware solution designed to manage the deployment and service software lifecycle of containerized applications. It also supports an optional separation of concerns between a service and related machine learning assets by providing a separate [model sync service](https://open-horizon.github.io/docs/developing/model_management_details/#model_management_details).  These solutions enable autonomous management of large fleets of edge compute nodes in various connected states.
+Open Horizon is a middleware solution designed to manage the deployment and service software lifecycle of containerized applications. It also supports an optional separation of concerns between a service and related machine learning assets by providing a separate [model sync service](developing/model_management_details.md#model_management_details).  These solutions enable autonomous management of large fleets of edge compute nodes in various connected states.
 
 Open Horizon allows you to install individual tools like the Management Hub control plane, the CLI for remote management using the command-line, or the anax Agent.  If you would like all three installed on a single machine, use the all-in-one installation provided below.
 
 ### All-in-one installation instructions
 
-To install a simple, developer-friendly version of [all the services on one device](https://open-horizon.github.io/docs/mgmt-hub/docs/), run the following one-liner as `root` on an x86_64 machine running Ubuntu 18.04 (see [all supported environments](https://open-horizon.github.io/docs/installing/adding_devices/#suparch-horizon)):
+To install a simple, developer-friendly version of [all the services on one device](docs/mgmt-hub/docs/index.md), run the following one-liner as `root` on an x86_64 machine running Ubuntu 18.04 (see [all supported environments](docs/installing/adding_devices.md#suparch-horizon)):
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/open-horizon/devops/master/mgmt-hub/deploy-mgmt-hub.sh | bash
@@ -65,7 +65,7 @@ If you've been provided with credentials by an administrator and just need to in
    curl -sSL https://github.com/open-horizon/anax/releases/latest/download/agent-install.sh | bash -s -- -i anax: -k ./agent-install.cfg -c css: -p IBM/pattern-ibm.helloworld -w '*' -T 120
    ```
 
-Alternatively, see the [detailed installation instructions](https://open-horizon.github.io/docs/installing/registration/#registration) for other methods of installing the Agent.
+Alternatively, see the [detailed installation instructions](docs/installing/registration.md#registration) for other methods of installing the Agent.
 
 ### Common requests
 
@@ -81,8 +81,8 @@ Alternatively, see the [detailed installation instructions](https://open-horizon
 
 ### Learn more
 
-[Developer Learning Path](/docs/getting_started/developer_learning_path/) page.
+[Developer Learning Path](docs/getting_started/developer_learning_path.md) page.
 
-From the [Getting Started Overview](/docs/getting_started/overview_oh/) page.
+From the [Getting Started Overview](docs/getting_started/overview_oh.md) page.
 
 From the [Open-Horizon Project Playlist](https://www.youtube.com/playlist?list=PLgohd895XSUddtseFy4HxCqTqqlYfW8Ix) on YouTube.

--- a/quick-start.md
+++ b/quick-start.md
@@ -1,7 +1,7 @@
 ---
 copyright:
 years: 2021 - 2023
-lastupdated: "2023-02-01"
+lastupdated: "2023-02-16"
 layout: page
 title: "Quick Start"
 description: "A guide to get you using Open Horizon in minutes."
@@ -13,15 +13,61 @@ has_toc: false
 
 ### Overview
 
-Open Horizon is a middleware solution designed to manage the deployment and service software lifecycle of containerized applications. It also supports an optional separation of concerns between a service and related machine learning assets by providing a separate model sync service.  These solutions enable autonomous management of large fleets of edge compute nodes in various connected states.
+Open Horizon is a middleware solution designed to manage the deployment and service software lifecycle of containerized applications. It also supports an optional separation of concerns between a service and related machine learning assets by providing a separate [model sync service](https://open-horizon.github.io/docs/developing/model_management_details/#model_management_details).  These solutions enable autonomous management of large fleets of edge compute nodes in various connected states.
 
-To install a simple, developer-friendly version of [all the services on one device](https://open-horizon.github.io/docs/mgmt-hub/docs/), run the following one-liner as `root` on an x86_64 machine running Ubuntu 18.04:
+Open Horizon allows you to install individual tools like the Management Hub control plane, the CLI for remote management using the command-line, or the anax Agent.  If you would like all three installed on a single machine, use the all-in-one installation provided below.
+
+### All-in-one installation instructions
+
+To install a simple, developer-friendly version of [all the services on one device](https://open-horizon.github.io/docs/mgmt-hub/docs/), run the following one-liner as `root` on an x86_64 machine running Ubuntu 18.04 (see [all supported environments](https://open-horizon.github.io/docs/installing/adding_devices/#suparch-horizon)):
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/open-horizon/devops/master/mgmt-hub/deploy-mgmt-hub.sh | bash
 ```
 
-### Common Requests
+### anax Agent installation instructions
+
+If you've been provided with credentials by an administrator and just need to install the Agent and CLI on your machine, use these steps:
+
+1. Log into your device and set the environment variables given to you, replacing the `<placeholders>` with real values applicable to you:
+
+   ```bash
+   export HZN_ORG_ID=<your exchange organization id>
+   export HZN_DEVICE_TOKEN=<specify a string value for a token>
+   export HZN_DEVICE_ID=<specify a string value to uniquely identify this device>
+   export HZN_EXCHANGE_USER_AUTH=<user id>:<password>
+   export HZN_EXCHANGE_URL=<management hub protocol and IP address>:3090/v1
+   export HZN_FSS_CSSURL=<management hub protocol and IP address>:9443/
+   export HZN_AGBOT_URL=<management hub protocol and IP address>:3111
+   export HZN_SDO_SVC_URL=<management hub protocol and IP address>:9008/api
+   ```
+
+1. Download and run the `agent-install.sh` script to get the necessary files from CSS (Cloud Sync Service), install and configure the Agent, and register your edge device to run the helloworld sample edge service:
+
+   ```bash
+   sudo -s -E curl -sSL https://github.com/open-horizon/anax/releases/latest/download/agent-install.sh | bash -s -- -i css: -p IBM/pattern-ibm.helloworld -w '*' -T 120
+   ```
+
+1. If the CSS on the Hub has not been populated with an Agent for your environment and/or default configuration, you may need to manually create that configuration and then use a slightly different installation technique:
+
+   A. Create a file named `agent-install.cfg` and populate it with the following, replacing the `<placeholders>` with real values applicable to you:
+
+   ```text
+   HZN_EXCHANGE_URL=<management hub protocol and IP address>:3090/v1
+   HZN_FSS_CSSURL=<management hub protocol and IP address>:9443/
+   HZN_AGBOT_URL=<management hub protocol and IP address>:3111
+   HZN_SDO_SVC_URL=<management hub protocol and IP address>:9008/api
+   ```
+  
+   B. Download and run the `agent-install.sh` script to install and configure the Agent and register your edge device to run the helloworld sample edge service:
+
+   ```bash
+   curl -sSL https://github.com/open-horizon/anax/releases/latest/download/agent-install.sh | bash -s -- -i anax: -k ./agent-install.cfg -c css: -p IBM/pattern-ibm.helloworld -w '*' -T 120
+   ```
+
+Alternatively, see the [detailed installation instructions](https://open-horizon.github.io/docs/installing/registration/#registration) for other methods of installing the Agent.
+
+### Common requests
 
 👩‍💻 How to [install Open Horizon](common-requests/install.md)
 
@@ -33,7 +79,7 @@ curl -sSL https://raw.githubusercontent.com/open-horizon/devops/master/mgmt-hub/
 
 📚 How to [get support for Open Horizon](common-requests/get-technical-support.md)
 
-### Learn More
+### Learn more
 
 [Developer Learning Path](/docs/getting_started/developer_learning_path/) page.
 


### PR DESCRIPTION
# Pull Request Template

## Description

Updated the Quick Start page to specify/clarify what is installed with "all-in-one" and to also have instructions for installing just the agent, which is applicable to those using the LF Edge Community Lab instance.  This will make it easier for new users and prevent admins from having to email agent install instructions.

Fixes #416 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I generated the documentation locally and viewed the page.

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->

@johnwalicki hopefully this doesn't add complexity, since the purpose is to simplify.  I also noticed that the env vars have significantly different path values from the agent installation docs elsewhere.  We may need to look into that later.  These values are what I send to all new Community Lab users, and are verified correct.

@Rene-Ch1 Let me know if I've introduced any grammatical errors or otherwise violated any best practices.