### PR TITLE
Issue 404: Keep sidebar from expanding

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -16,7 +16,7 @@
   }
 
   @include mq(lg) {
-    width: calc((100% - #{$nav-width + $content-width}) / 2 + #{$nav-width});
+    width: 10%;
     min-width: $nav-width;
   }
 }


### PR DESCRIPTION
## Description

[Issue 404](https://github.com/open-horizon/open-horizon.github.io/issues/404): 
The sidebar expands very wide when you increase the size of the browser.  @joewxboy 

- [ x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

I set a static size sidebar on the page. When the screen grows wider, it does not. When the screen becomes too narrow, the sidebar disappears. The top browser is my local change, compared with the original in the lower portion of the screenshot. 

![65BC896A-D2DA-4799-9442-65AE8CE576C7](https://user-images.githubusercontent.com/25189332/229181352-9cad553f-280c-4e0e-ae5b-3fc366facc43.jpeg)
