### PR TITLE
Remove "Intel" from the phrase "Intel FDO"

### DIFF
--- a/docs/api/fdo_swagger.json
+++ b/docs/api/fdo_swagger.json
@@ -1,7 +1,7 @@
 {
     "swagger": "2.0",
     "info": {
-      "description": "[Intel FDO](https://software.intel.com/en-us/secure-device-onboard) (Secure Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an IEAM instance. IEAM has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the IEAM management hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
+      "description": "[FDO](https://software.intel.com/en-us/secure-device-onboard) (Secure Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an IEAM instance. IEAM has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the IEAM management hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
       "version": "1.0.0",
       "title": "Open Horizon Support for FDO",
       "license": {

--- a/docs/fdo/docs/ocs-api-swagger.json
+++ b/docs/fdo/docs/ocs-api-swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "[Intel FDO](https://software.intel.com/en-us/secure-device-onboard) (FIDO Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an Open Horizon Management Hub instance. Open Horizon has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the Open Horizon Management Hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
+    "description": "[FDO](https://software.intel.com/en-us/secure-device-onboard) (FIDO Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an Open Horizon Management Hub instance. Open Horizon has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the Open Horizon Management Hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
     "version": "1.2.0",
     "title": "Open Horizon Support for FDO",
     "license": {

--- a/docs/fdo/docs/ocs-api-swagger.yml
+++ b/docs/fdo/docs/ocs-api-swagger.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Open Horizon Support for FDO
-  description: '[Intel FDO](https://software.intel.com/en-us/secure-device-onboard)
+  description: '[FDO](https://software.intel.com/en-us/secure-device-onboard)
     (FIDO Device Onboard) is a technology that is created by Intel to make it easy
     and secure to configure edge devices and associate them with an Open Horizon Management
     Hub instance. Open Horizon has added support for FDO-enabled devices so that the

--- a/docs/fdo/ocs-api-swagger.json
+++ b/docs/fdo/ocs-api-swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "[Intel FDO](https://software.intel.com/en-us/secure-device-onboard) (Secure Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an IEAM instance. IEAM has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the IEAM management hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
+    "description": "[FDO](https://software.intel.com/en-us/secure-device-onboard) (Secure Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an IEAM instance. IEAM has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the IEAM management hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
     "version": "1.0.0",
     "title": "Open Horizon Support for FDO",
     "license": {

--- a/docs/installing/fdo.md
+++ b/docs/installing/fdo.md
@@ -20,7 +20,7 @@ nav_order: 6
 # FDO agent installation and registration
 {: #fdo}
 
-[FIDO Device Onboard (FDO) ](https://github.com/open-horizon/FDO-support/blob/main/README.md){:target="_blank"}{: .externalLink}, created by Intel, makes it easy to add edge devices built with Intel FDO (FIDO Device Onboard) to an {{site.data.keyword.ieam}} instance by simply importing their associated ownership vouchers and then powering on the devices.
+[FIDO Device Onboard (FDO) ](https://github.com/open-horizon/FDO-support/blob/main/README.md){:target="_blank"}{: .externalLink}, created by Intel, makes it easy to add edge devices built with FDO (FIDO Device Onboard) to an {{site.data.keyword.ieam}} instance by simply importing their associated ownership vouchers and then powering on the devices.
 
 ## FDO overview
 {: #fdo-overview}


### PR DESCRIPTION
## Description

**Removed "Intel" from the phrase "Intel FDO" as the FDO project has requested that we change it to read merely "FDO" instead.**

Fixes #513 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
