### PR TITLE
Issue 614: updating docs for deployment policy auto updating

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-years: 2021 - 2024
-lastupdated: "2024-04-08"
+years: 2021 - 2025
+lastupdated: "2025-02-20"
 layout: page
 title: "Docs"
 description: "Welcome to the Open Horizon (OH) documentation section, where you can find information about installing, maintaining, and using the project software."
@@ -172,6 +172,9 @@ nav_order: 3
 							</li>
 							<li class="ibm-link-description">
 								<a href="developing/">Developing edge services</a>
+							</li>
+							<li class="ibm-link-description">
+								<a href="using_edge_services/service_rollbacks/">Upgrading a service with rollback</a>
 							</li>
 						</ul>
 					</div>

--- a/docs/using_edge_services/service_rollbacks.md
+++ b/docs/using_edge_services/service_rollbacks.md
@@ -1,8 +1,8 @@
 ---
 copyright:
-years: 2020 - 2023
-lastupdated: "2023-03-13"
-title: Updating an edge service with rollback
+years: 2020 - 2025
+lastupdated: "2025-02-20"
+title: Automatically updating an edge service with rollback
 description: ""
 
 parent: Edge services for devices
@@ -91,6 +91,8 @@ hzn deploycheck -h
 The {{site.data.keyword.ieam}} {{site.data.keyword.agbot}}s quickly detect the deployment pattern or deployment policy changes. The {{site.data.keyword.agbot}}s then reach out to each agent whose edge node is either registered to run the deployment pattern or is compatible with the updated deployment policy. The {{site.data.keyword.agbot}} and the agent coordinate to download the new containers, stop and remove the old containers, and start the new containers.
 
 As a result, your edge nodes that are either registered to run the updated deployment pattern or are compatible with the deployment policy quickly runs the new edge service version with the top priority value, regardless of where the edge node is geographically located.
+
+A complete example Deployment Policy is available in the [{{site.data.keyword.ieam}} GitHub repository CLI examples](https://github.com/open-horizon/anax/blob/master/cli/samples/business_policy.json).
 
 ## Viewing progress of new service version being rolled out
 {: #viewing_rollback_progress}


### PR DESCRIPTION
# Pull Request Template

## Description

Updated the existing rollback docs page to make it clearer that this also updates existing deployed services, and providing a link to an example policy.  Also updating the main index to add a link to this page.

Fixes #614 

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update


...

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->

This was for the Edge Lake team at their request.