### PR TITLE
add a new bullet

### DIFF
--- a/docs/installing/fdo.md
+++ b/docs/installing/fdo.md
@@ -30,6 +30,7 @@ The software in the FDO git repository provides integration between FDO and {{si
 * A docker image of of the FDO Owner service (those that run on the {{site.data.keyword.edge_notm}} management hub).
 * An `hzn fdo voucher` sub-command to import one or more ownership vouchers into Owner service. (An ownership voucher is a file that the device manufacturer gives to the purchaser (owner) along with the physical device.)
 * A sample script called `start-mfg.sh` to start the development manufacturing service so that the ownership voucher can be extended to the user to enable them to run through the FDO-enabling steps on a Virtual Machine (VM) device that a device manufacturer would run on a physical device. This allows you to try out the FDO process with your Horizon instance before purchasing FDO-enabled devices.
+* A sample script called start-rv.sh that you use to set up a development version of the FDO Rendezvous server. The script creates an environment where you can test the Rendezvous server and simulate the FDO onboarding process. You can also test the voucher exchange process for the device ownership transfer before you deploy FDO-enabled devices. To download the start-rv.sh script, see FDO support (https://github.com/open-horizon/FDO-support/blob/main/sample-rv/start-rv.sh).
 * A REST API that authenticates users through the Horizon Exchange and enables importing and querying ownership vouchers.
 
 **Note**: FDO only supports edge devices, not edge clusters.


### PR DESCRIPTION
## Description

Added a new bullet point under the **FDO overview** section in `docs/installing/fdo.md`.  
The new bullet describes the `start-rv.sh` script, which sets up a development version of the FDO Rendezvous server. This provides a way to test the onboarding process and voucher exchange before deploying FDO-enabled devices.

Fixes # (issue)

## Type of change

- [x] Documentation update (adds new explanation to existing docs)

## How Has This Been Tested?

- Verified that the documentation renders correctly in Markdown format.
- Checked that the new bullet appears as the 4th item in the FDO overview list.

## Additional Context (Please include any Screenshots/gifs if relevant)

N/A

## Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] I have checked my code and corrected any misspellings  
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO)  

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
