### PR TITLE
fixed

### DIFF
--- a/docs/installing/edge_cluster_agent.md
+++ b/docs/installing/edge_cluster_agent.md
@@ -3,7 +3,7 @@ copyright: Contributors to the Open Horizon project
 years: 2022 - 2025
 title: Installing the edge cluster agent
 description: Documentation for Installing the edge cluster agent
-lastupdated: 2025-09-02
+lastupdated: 2025-10-07
 nav_order: 2
 parent: Edge clusters
 ---

--- a/docs/installing/edge_cluster_agent.md
+++ b/docs/installing/edge_cluster_agent.md
@@ -218,10 +218,10 @@ This content describes how to install the {{site.data.keyword.ieam}} agent on yo
     ```
     {: codeblock}
 
-   **Notes**:
-   * To see all of the available flags, run: **./agent-install.sh -h**
-   * If an error causes **agent-install.sh** to fail, correct the error and run **agent-install.sh** again. If that does not work, run **agent-uninstall.sh** (see [Removing agent from edge cluster](../using_edge_services/removing_agent_from_cluster.md)) before running **agent-install.sh** again.
-
+       **Notes**:
+       * To see all of the available flags, run: **./agent-install.sh -h**
+       * If an error causes **agent-install.sh** to fail, correct the error and run **agent-install.sh** again. If that does not work, run **agent-uninstall.sh** (see [Removing agent from edge cluster](../using_edge_services/removing_agent_from_cluster.md)) before running **agent-install.sh** again.
+    
 19. Change to the agent namespace (also known as project) and verify that the agent pod is running:
 
     ```bash


### PR DESCRIPTION
## Description

Added a new bullet point under the **FDO overview** section in `docs/installing/fdo.md`.  
The new bullet describes the `start-rv.sh` script, which sets up a development version of the FDO Rendezvous server. This provides a way to test the onboarding process and voucher exchange before deploying FDO-enabled devices.

Fixes # (issue)

## Type of change

- [x] Documentation update (adds new explanation to existing docs)

## How Has This Been Tested?

- Verified that the documentation renders correctly in Markdown format.
- Checked that the new bullet appears as the 4th item in the FDO overview list.

## Additional Context (Please include any Screenshots/gifs if relevant)

N/A

## Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] I have checked my code and corrected any misspellings  
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO)  

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
