### PR TITLE
Issue 646: Remove link on docs index page for mimik integration

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -218,9 +218,6 @@ layout: page
 						<h3 class="linklistlabel ibm-h3 ibm-textcolor-blue-50">Integrating</h3>
 						<ul class="ibm-colored-list ibm-textcolor-gray-80 ibm-plain-list">
 							<li class="ibm-link-description">
-								mimik edgeEngine integration
-							</li>
-							<li class="ibm-link-description">
 								<a href="kubearmor-integration/docs/README/">AccuKnox Kubearmor integration</a>
 							</li>
 						</ul>


### PR DESCRIPTION
# Pull Request Template

## Description

Removed mimik integration from the integrations section on the docs index page due to the code being deprecated.

Fixes #646 

...

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [X] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
