### PR TITLE
Fix orphan pages checker false positive failure

### DIFF
--- a/.github/workflows/orphan_pages_checker.yml
+++ b/.github/workflows/orphan_pages_checker.yml
@@ -13,11 +13,11 @@ jobs:
     checker:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: ruby/setup-ruby@v1
               with:
-                  ruby-version: '3.2.1' # Not needed with a .ruby-version file
-                  bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+                  ruby-version: '3.2.1'
+                  bundler-cache: true
             - run: |
                   make init
                   bundle exec jekyll serve >/dev/null 2>&1 &
@@ -32,8 +32,17 @@ jobs:
                   kill -15 $pid
                   printf "Killed the Server\n"
                   printf "Finding Orphan Pages\n"
-                  diff -qr 127.0.0.1\:4000/ ./_site | grep Only | grep .html | grep -v 404.html | grep -v dir.html | grep -v oauth2-redirect.html
+                  orphans=$(diff -qr 127.0.0.1\:4000/ ./_site | grep Only | grep .html | grep -v 404.html | grep -v dir.html | grep -v oauth2-redirect.html || true)
+                  if [ -n "$orphans" ]; then
+                    echo "Found orphan pages:"
+                    echo "$orphans"
+                    exit 1
+                  else
+                    echo "No orphan pages found - site is clean!"
+                    exit 0
+                  fi
             - name: Creating issue
+              if: failure()
               uses: JasonEtco/create-an-issue@v2.4.0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Handle grep exit code properly when no orphans found
- Update actions/checkout to v4 for Node.js 24 support
- Add 'if: failure()' condition to issue creation step

The workflow was failing with exit code 1 when no orphan pages were found because grep returns exit code 1 when no matches exist. This is actually a success condition (no orphans = good).

Changes:
1. Capture grep output in variable with '|| true' to prevent pipeline failure
2. Explicitly check if orphans exist and exit accordingly
3. Update actions/checkout from v3 to v4 to eliminate Node.js deprecation warning
4. Only create issue on actual failure

Fixes: #716 

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #716 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
